### PR TITLE
Cosmos DB account must be lowercase

### DIFF
--- a/deploymentscript.ps1
+++ b/deploymentscript.ps1
@@ -61,7 +61,7 @@ if([string]::IsNullOrWhiteSpace($location)) {
 $resourceGroup = $deploymentName + $location + "-rg"
 Write-Host "Creating resource group " $resourceGroup
 az group create --location $location --name $resourceGroup --subscription $selectedSubscription
-$databaseName = $deploymentName + "db"
+$databaseName = $deploymentName.ToLower() + "db"
 
 Write-Host "Deploying Sample application.. (this might take a few minutes)"
 $deploymentOutputs = az deployment group create --resource-group $resourceGroup --subscription $selectedSubscription --mode Incremental --template-file ./windows-webapp-template.json --parameters "webAppName=$deploymentName" --parameters "hostingPlanName=$deploymentName-host" --parameters "appInsightsLocation=$location" --parameters "databaseAccountId=$databaseName" --parameters "databaseAccountLocation=$location" -o json


### PR DESCRIPTION
## Purpose
* Update the deployment script to ensure the generated Cosmos DB account name is only using lowercase. 
Several users have gotten a 503 error when loading the sample application because the Cosmos DB could not be created as a result of incorrect naming. 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?
* Update the sample application deployment script to force the Cosmos DB account name to be lowercase.

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* Run `deploymentscript.ps1` and provide an uppercase web app name as input.
* Verify that the Cosmos DB account is successfully created.

## Other Information
<!-- Add any other helpful information that may be needed here. -->